### PR TITLE
refactor/gameId vote input

### DIFF
--- a/src/auth/guards/gql-game.guard.ts
+++ b/src/auth/guards/gql-game.guard.ts
@@ -13,13 +13,12 @@ export class GqlGameGuard implements CanActivate {
   ): boolean | Promise<boolean> | Observable<boolean> {
     const ctx = GqlExecutionContext.create(context);
 
-    const { gameId, id } = ctx.getArgs();
+    const { gameId: argsGameId } = ctx.getArgs();
     const { req, extra } = ctx.getContext();
 
     const user = extra ? extra.request.user : req.user;
 
-    const IdFromArgs = gameId || id;
-    if (IdFromArgs !== user.gameId)
+    if (argsGameId !== user.gameId)
       throw new AuthenticationError(
         'You have no permission to access this game',
       );

--- a/src/game/models/GetGame.args.ts
+++ b/src/game/models/GetGame.args.ts
@@ -1,7 +1,7 @@
 import { ArgsType, Field } from '@nestjs/graphql';
 
 @ArgsType()
-export class GetGameVotesArgs {
+export class GetGameArgs {
   @Field(() => String, { description: 'Game id' })
   readonly gameId!: string;
 }

--- a/src/game/models/GetGameVotesArgs.ts
+++ b/src/game/models/GetGameVotesArgs.ts
@@ -3,5 +3,5 @@ import { ArgsType, Field } from '@nestjs/graphql';
 @ArgsType()
 export class GetGameVotesArgs {
   @Field(() => String, { description: 'Game id' })
-  readonly id!: string;
+  readonly gameId!: string;
 }

--- a/src/game/models/PlayerVote.args.ts
+++ b/src/game/models/PlayerVote.args.ts
@@ -3,6 +3,9 @@ import { PlayerVoteInput } from './PlayerVote.input';
 
 @ArgsType()
 export class PlayerVoteArgs {
+  @Field(() => String, { description: 'Id of existing game' })
+  readonly gameId: string;
+
   @Field(() => PlayerVoteInput, { description: 'Player vote in game input' })
   readonly input!: PlayerVoteInput;
 }

--- a/src/game/models/index.ts
+++ b/src/game/models/index.ts
@@ -4,4 +4,4 @@ export * from './Game.model';
 export * from './JoinGame.input';
 export * from './PlayerVote.args';
 export * from './PlayerVote.input';
-export * from './GetGameVotesArgs';
+export * from './GetGame.args';

--- a/src/game/resolvers/game-mutations.resolver.ts
+++ b/src/game/resolvers/game-mutations.resolver.ts
@@ -11,10 +11,11 @@ import { GameService } from '../game.service';
 import { GameSubscriptions } from '../types/pub-sub.types';
 import { UseGuards } from '@nestjs/common';
 import { GqlAuthGuard, GqlGameGuard } from 'src/auth/guards';
-import { Request, Response } from 'express';
+import { Response } from 'express';
 import { ConfigService } from '@nestjs/config';
 import { accessTokenKey } from 'src/constants';
 import { RedisPubSubService } from 'src/redis-cache/redis-pubsub.service';
+import { GqlUserInfos } from 'src/common/decorators/gql-user-infos.decorator';
 
 @Resolver('Game')
 export class GameMutationsResolver {
@@ -63,7 +64,7 @@ export class GameMutationsResolver {
   @UseGuards(GqlAuthGuard, GqlGameGuard)
   @Mutation(() => CurrentGame)
   async playerVote(
-    @Context('req') { user }: Request,
+    @GqlUserInfos() user: UserSession,
     @Args() args: PlayerVoteArgs,
   ): Promise<CurrentGame> {
     const { input } = args;

--- a/src/game/resolvers/game-queries.resolver.ts
+++ b/src/game/resolvers/game-queries.resolver.ts
@@ -1,12 +1,10 @@
-import { Args, Context, Query, Resolver } from '@nestjs/graphql';
-import { RedisPubSub } from 'graphql-redis-subscriptions';
+import { Args, Query, Resolver } from '@nestjs/graphql';
 import { RedisCacheService } from 'src/redis-cache/redis-cache.service';
-import { CurrentGame, GetGameVotesArgs } from '../models';
+import { CurrentGame, GetGameArgs } from '../models';
 import { GameService } from '../game.service';
 import { GameSubscriptions } from '../types/pub-sub.types';
 import { UseGuards } from '@nestjs/common';
 import { GqlAuthGuard, GqlGameGuard, GqlRolesGuard } from 'src/auth/guards';
-import { Request } from 'express';
 import { Roles } from 'src/common/decorators/roles.decorator';
 import { RedisPubSubService } from 'src/redis-cache/redis-pubsub.service';
 import { ForbiddenError } from 'apollo-server-express';
@@ -21,11 +19,10 @@ export class GameQueriesResolver {
 
   @UseGuards(GqlAuthGuard, GqlGameGuard)
   @Query(() => CurrentGame, { nullable: true })
-  async getOneGame(
-    @Args('id', { nullable: false, type: () => String })
-    id: string,
-  ): Promise<CurrentGame | null> {
-    const game = await this.cacheManager.get<CurrentGame>(`game_${id}`);
+  async getOneGame(@Args() args: GetGameArgs): Promise<CurrentGame | null> {
+    const game = await this.cacheManager.get<CurrentGame>(
+      `game_${args.gameId}`,
+    );
 
     if (game) return this.gameService.hidePlayersVotes(game);
 
@@ -35,30 +32,20 @@ export class GameQueriesResolver {
   @UseGuards(GqlAuthGuard, GqlRolesGuard, GqlGameGuard)
   @Roles('scrumMaster')
   @Query(() => CurrentGame, { nullable: true })
-  async getGameVotes(
-    @Context('pubsub') pubSub: RedisPubSub,
-    @Context('req') { user }: Request,
-    @Args() args: GetGameVotesArgs,
-  ): Promise<CurrentGame | null> {
-    const { id } = args;
-    const { gameId } = user;
+  async getGameVotes(@Args() args: GetGameArgs): Promise<CurrentGame | null> {
+    const { gameId } = args;
+    const game = await this.cacheManager.get<CurrentGame>(`game_${gameId}`);
 
-    if (id === gameId) {
-      const game = await this.cacheManager.get<CurrentGame>(`game_${id}`);
-
-      if (!game.users.every((user) => user.vote !== null)) {
-        throw new ForbiddenError(
-          'All players must have voted to reveal the result',
-        );
-      }
-
-      this.redisPubSub.publish(`${GameSubscriptions.PLAYING_GAME}_${id}`, {
-        [GameSubscriptions.PLAYING_GAME]: game,
-      });
-
-      return game;
+    if (!game.users.every((user) => user.vote !== null)) {
+      throw new ForbiddenError(
+        'All players must have voted to reveal the result',
+      );
     }
 
-    throw new ForbiddenError('You are not allowed to see this ressource');
+    this.redisPubSub.publish(`${GameSubscriptions.PLAYING_GAME}_${gameId}`, {
+      [GameSubscriptions.PLAYING_GAME]: game,
+    });
+
+    return game;
   }
 }


### PR DESCRIPTION
- :recycle: (args) Add gameId to player vote args.
- :recycle: (args) Standardize gameId as the reference key to retrieve a game
- :art: (args) Rename vote args into game to use it in getOne resolver
- :fire: (queries) Prune useless logic/code. Applys new args to resolvers

Closes #27,#72
